### PR TITLE
Add Baidu spiders to known bots list

### DIFF
--- a/user_agent.go
+++ b/user_agent.go
@@ -76,6 +76,7 @@ var knownBrowsers = []string{
 var knownBots = []string{
 	"ADmantX",
 	"AlexaToolbar/",
+	"Baiduspider",
 	"BingPreview/",
 	"Chrome-Lighthouse",
 	"DumpRenderTree/",


### PR DESCRIPTION
Baidu uses the same prefix for all its spiders. cf. http://www.baiduguide.com/baidu-spider/